### PR TITLE
Fix: foreign keys order

### DIFF
--- a/src/SchemaAnalyzer.php
+++ b/src/SchemaAnalyzer.php
@@ -268,9 +268,11 @@ class SchemaAnalyzer
                 if ($fk->getForeignTableName() == $currentTable) {
                     $foreignKeys[] = $fk;
                     $foreignKeys[] = $junctionFks[1];
+                    $currentTable = $junctionFks[1]->getForeignTableName();
                 } else {
                     $foreignKeys[] = $junctionFks[1];
                     $foreignKeys[] = $fk;
+                    $currentTable = $fk->getForeignTableName();
                 }
             } else {
                 // @codeCoverageIgnoreStart


### PR DESCRIPTION
When walking through junction table, the variable `$currentTable` was not updated. Therefore, in case of successive junction tables, the order of the foreign keys as not well ensured.