### PR TITLE
Adding support for @Autoincrement annotation

### DIFF
--- a/src/SchemaAnalyzer.php
+++ b/src/SchemaAnalyzer.php
@@ -168,7 +168,8 @@ class SchemaAnalyzer
             }
 
             // Let's check that the primary key is autoincremented
-            if (!$table->getColumn($pkColumns[0])->getAutoincrement()) {
+            $pkColumn = $table->getColumn($pkColumns[0]);
+            if (!$pkColumn->getAutoincrement() && strpos($pkColumn->getComment(), '@Autoincrement') === false) {
                 return false;
             }
         }


### PR DESCRIPTION
... to manually declare an autoincremented column for junction table detection.

Useful in Oracle since DBAL does not support detecting autoincremented keys.